### PR TITLE
채팅 페이지 기능 추가 및 디자인 수정

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -5,7 +5,7 @@ const AvatarComponent = ({ src, loading = 'lazy', ...rest }: AvatarProps) => {
   //유저 이미지 없을 경우 기본 농부 이미지
   const profileSrc = src || DefaultProfile;
 
-  return <Avatar src={profileSrc} loading={loading} {...rest} />;
+  return <Avatar src={profileSrc} loading={loading} {...rest} icon={<></>} />;
 };
 
 export default AvatarComponent;

--- a/src/pages/Chat/ChatContent/components/ChatBubble.tsx
+++ b/src/pages/Chat/ChatContent/components/ChatBubble.tsx
@@ -1,18 +1,27 @@
 import { Flex, Text } from '@chakra-ui/react';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
 import { AvatarComponent } from '@/components';
 import { ChatContent } from '@/services/chat/type';
 
+dayjs.locale('ko');
+
 interface ChatBubbleProps {
-  isMine: boolean;
   chat: ChatContent;
+  isMine: boolean;
   profile: string;
 }
 
-const ChatBubble = ({ chat, isMine, profile }: ChatBubbleProps) => {
-  const { contents } = chat;
+const ChatBubble = ({ chat, profile, isMine }: ChatBubbleProps) => {
+  const { contents, createdAt, readOrNot } = chat;
+  const formattedTime = dayjs(createdAt).format('A hh:mm');
 
   return (
-    <Flex gap="16px" justifyContent={isMine ? 'flex-end' : 'flex-start'}>
+    <Flex
+      gap="16px"
+      justifyContent={isMine ? 'flex-end' : 'flex-start'}
+      alignItems="center"
+    >
       {!isMine && (
         <AvatarComponent
           width={{ mobile: '38px', tablet: '52px' }}
@@ -20,12 +29,17 @@ const ChatBubble = ({ chat, isMine, profile }: ChatBubbleProps) => {
           src={profile}
         />
       )}
-      <Flex gap={{ mobile: '8px', tablet: '10px' }}>
+
+      <Flex
+        gap={{ mobile: '8px', tablet: '10px' }}
+        flexDirection={isMine ? 'row-reverse' : 'row'}
+      >
         <Text
           maxW="200px"
           wordBreak="break-all"
           fontSize="16px"
           fontWeight="medium"
+          h="fit-content"
           p={{ mobile: '8px 12px', tablet: '10px 13px' }}
           bg="orange.400"
           rounded="10px"
@@ -33,15 +47,27 @@ const ChatBubble = ({ chat, isMine, profile }: ChatBubbleProps) => {
         >
           {contents}
         </Text>
-        <Text
-          fontSize={{ mobile: '12px', tablet: '16px' }}
-          color="gray.400"
-          flexShrink="0"
-          alignSelf="flex-end"
-          order={isMine ? '-1' : '1'}
-        >
-          오전 12시 10분
-        </Text>
+        <Flex flexDirection="column" justifyContent="flex-end">
+          {isMine && !readOrNot && (
+            <Text
+              fontSize={{ mobile: '10px', tablet: '12px' }}
+              color="orange.500"
+              flexShrink="0"
+              alignSelf="flex-end"
+              lineHeight="10px"
+            >
+              1
+            </Text>
+          )}
+          <Text
+            fontSize={{ mobile: '12px', tablet: '14px' }}
+            color="gray.400"
+            flexShrink="0"
+            alignSelf="flex-end"
+          >
+            {formattedTime}
+          </Text>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/src/pages/Chat/ChatContent/components/ContentHeader.tsx
+++ b/src/pages/Chat/ChatContent/components/ContentHeader.tsx
@@ -1,9 +1,14 @@
 import { Text, Image, Flex } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 import BtnItems from './BtnItems';
 import MobileHeader from './MobileHeader';
 import { EnterChatRoom } from '@/services/chat/type';
+import { useGetIndividualGarden } from '@/services/gardens/query';
+import useMapGardenDetailIdStore from '@/stores/useMapGardenDetailIdStore';
 
 const ContentHeader = ({ productInfo }: { productInfo: EnterChatRoom }) => {
+  const navigate = useNavigate();
+  const { setGardenId } = useMapGardenDetailIdStore();
   const {
     gardenName,
     gardenStatus,
@@ -12,6 +17,20 @@ const ContentHeader = ({ productInfo }: { productInfo: EnterChatRoom }) => {
     price,
     partnerMannerGrade,
   } = productInfo;
+  const { data: gardenDetailData } = useGetIndividualGarden(productInfo.postId);
+
+  const handleGardenInfoClick = () => {
+    if (!gardenDetailData) return;
+    navigate('/map', {
+      state: {
+        data: {
+          lat: gardenDetailData.latitude,
+          lng: gardenDetailData.longitude,
+        },
+      },
+    });
+    setGardenId(gardenDetailData.gardenId);
+  };
 
   return (
     <Flex
@@ -32,22 +51,30 @@ const ContentHeader = ({ productInfo }: { productInfo: EnterChatRoom }) => {
         partnerMannerGrade={partnerMannerGrade}
       />
       <Flex alignItems="center" gap="15px">
-        <Image
-          w={{ mobile: '52px', tablet: '52px' }}
-          h={{ mobile: '52px', tablet: '52px' }}
-          borderRadius="10px"
-          backgroundColor="gray.100"
-          src={images[0]}
-          flexShrink={0}
-        />
+        {gardenDetailData && (
+          <Image
+            w={{ mobile: '52px', tablet: '52px' }}
+            h={{ mobile: '52px', tablet: '52px' }}
+            borderRadius="10px"
+            backgroundColor="gray.100"
+            src={images[0]}
+            flexShrink={0}
+            cursor="pointer"
+            onClick={handleGardenInfoClick}
+          />
+        )}
         <Flex flexDirection="column">
-          <Flex alignItems="center" gap="8px">
+          <Flex
+            alignItems="center"
+            gap="8px"
+            onClick={handleGardenInfoClick}
+            cursor="pointer"
+          >
             <Text
               fontSize={{ mobile: '16px', tablet: '18px' }}
               fontWeight="semiBold"
             >
               {gardenStatus === 'ACTIVE' ? '분양중' : '분양 완료'}
-              분양중
             </Text>
             <Text
               fontSize={{ mobile: '16px', tablet: '18px' }}

--- a/src/pages/Chat/ChatList/ChatListItem.tsx
+++ b/src/pages/Chat/ChatList/ChatListItem.tsx
@@ -5,7 +5,8 @@ import { ChatRoom } from '@/services/chat/type';
 
 const ChatListItem = ({ chat }: { chat: ChatRoom }) => {
   const navigate = useNavigate();
-  const { partnerInfo, recentContents, postInfo, chatRoomId } = chat;
+  const { partnerInfo, recentContents, postInfo, chatRoomId, readNotCnt } =
+    chat;
   const { imageUrl, nickName } = partnerInfo;
 
   const handleEnterChatRoom = () => {
@@ -43,16 +44,32 @@ const ChatListItem = ({ chat }: { chat: ChatRoom }) => {
               씨앗 · 1분전
             </Text>
           </Flex>
-          <Text
-            w={{ mobile: 'calc(100vw - 270px)', tablet: '200px' }}
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-            fontWeight="500"
-            fontSize="16px"
-            overflow="hidden"
-          >
-            {recentContents}
-          </Text>
+          <Flex gap="8px">
+            <Text
+              maxW={{ mobile: 'calc(100vw - 270px)', tablet: '170px' }}
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+              fontWeight="500"
+              fontSize="16px"
+              overflow="hidden"
+            >
+              {recentContents}
+            </Text>
+            {readNotCnt > 0 && (
+              <Flex
+                justifyContent="center"
+                alignItems="center"
+                px="5px"
+                fontWeight="semiBold"
+                fontSize="14px"
+                rounded="10px"
+                bg="#FF5C00"
+                color="white"
+              >
+                {readNotCnt > 99 ? '99+' : readNotCnt}
+              </Flex>
+            )}
+          </Flex>
         </Box>
       </Flex>
       <Image

--- a/src/pages/Chat/ChatList/ChatListItem.tsx
+++ b/src/pages/Chat/ChatList/ChatListItem.tsx
@@ -2,12 +2,15 @@ import { Box, Flex, Image, Text } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import { AvatarComponent } from '@/components';
 import { ChatRoom } from '@/services/chat/type';
+import getRelativeTime from '@/utils/getRelativeTime';
 
 const ChatListItem = ({ chat }: { chat: ChatRoom }) => {
   const navigate = useNavigate();
   const { partnerInfo, recentContents, postInfo, chatRoomId, readNotCnt } =
     chat;
   const { imageUrl, nickName } = partnerInfo;
+
+  const lastMessageTime = getRelativeTime(chat.createdAt);
 
   const handleEnterChatRoom = () => {
     navigate(`/chat/${chatRoomId}`);
@@ -41,7 +44,7 @@ const ChatListItem = ({ chat }: { chat: ChatRoom }) => {
               {nickName}
             </Text>
             <Text fontWeight="regular" fontSize="14px">
-              씨앗 · 1분전
+              {partnerInfo.memberMannerGrade} · {lastMessageTime}
             </Text>
           </Flex>
           <Flex gap="8px">

--- a/src/services/chat/type.ts
+++ b/src/services/chat/type.ts
@@ -34,9 +34,10 @@ export interface EnterChatRoom {
 
 export interface ChatContent {
   chatMessageId: number;
+  chatRoomId: number;
   memberId: number;
   contents: string;
-  createdAt: number[];
+  createdAt: string;
   readOrNot: boolean;
 }
 

--- a/src/services/chat/type.ts
+++ b/src/services/chat/type.ts
@@ -1,3 +1,5 @@
+import { Grade } from '@/types/grade';
+
 export interface ChatRoom {
   recentContents: string;
   readNotCnt: number;
@@ -9,6 +11,7 @@ export interface ChatRoom {
     partnerId: number;
     nickName: string;
     imageUrl: string | undefined;
+    memberMannerGrade: Grade;
   };
   createdAt: string;
   chatRoomId: number;

--- a/src/services/gardens/api.ts
+++ b/src/services/gardens/api.ts
@@ -7,7 +7,7 @@ const gardensAPI = {
     return response.data;
   },
 
-  getIndividualGarden: async (id: number | null) => {
+  getIndividualGarden: async (id: number | null): Promise<GardenDetail> => {
     const response = await apiClient.get(`/v2/gardens/${id}`);
 
     return response.data;


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

-  채팅 페이지에 지도 페이지로 이동 기능 추가
-  말풍선 디자인 수정
-  Avatar 컴포넌트 기본 이미지가 로딩되기 전에 기본 아이콘이 보이는 현상 수정
-  말풍선 날씨 수정
-  읽지 않은 메시지 갯수 출력 뱃치 추가

<br/>

## 🚧 참고 사항

아바타 컴포넌트가 렌더링될때 일시적으로 기본 이미지가 아닌 chakra에서 설정한 아이콘이 보이는 문제는 avatar 컴포넌트 자체적으로 기본 아이콘을 먼저 렌더링한 후 저희가 설정한 기본 이미지를 로드해서 발생한 문제였습니다. 아이콘을 없애는 것으로 일시적으로 해결했지만 관련 옵션을 조금더 찾아보고 추가로 수정하겠습니다.

close #91 
