### PR TITLE
fix: 속닥속닥 댓글 엔터키 입력 방지

### DIFF
--- a/src/pages/Community/CommunityDetail/components/CommentInput.tsx
+++ b/src/pages/Community/CommunityDetail/components/CommentInput.tsx
@@ -50,8 +50,7 @@ const CommentInput = ({
           ref={commentRef}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
-              handleSubmitComment(commentRef.current?.value ?? '', commentId);
-              commentRef.current!.value = '';
+              e.preventDefault();
             }
           }}
           autoFocus={autoFocus}


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->
댓글 입력시 엔터키 입력 방지
<br/>

## 🚧 참고 사항
프론트 개발서버에서 소셜로그인이 안되는 이슈가 있어서 댓글을 직접 달아보면서 테스트 하지는 못했습니다. 엔터키로 댓글 못달게 방지는 해놔서, 추후에 테스트가 필요합니다.
<br/>

<!-- ## ❓ 궁금한 점 -->

close #112 
