### PR TITLE
fix: 지도 페이지 텃밭 리스트에서 하나의 텃밭 클릭 시 텃밭 상세보기가 보이지 않는 문제 해결

### DIFF
--- a/src/pages/Main/components/RecentPosts/RecentPostItem.tsx
+++ b/src/pages/Main/components/RecentPosts/RecentPostItem.tsx
@@ -3,10 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import { DefaultPost } from '@/assets/images';
 import { GardenPost } from '@/services/gardenPost/types';
 import useMapGardenDetailIdStore from '@/stores/useMapGardenDetailIdStore';
+import useShowGardenDetailStore from '@/stores/useShowGardenDetailStore';
 
 const RecentPostItem = ({ postData }: { postData: GardenPost }) => {
   const navigate = useNavigate();
-  const { setGardenId } = useMapGardenDetailIdStore();
+  const setGardenId = useMapGardenDetailIdStore((state) => state.setGardenId);
+  const setShowGardenDetail = useShowGardenDetailStore(
+    (state) => state.setShowGardenDetail,
+  );
 
   const {
     imageUrl,
@@ -39,6 +43,7 @@ const RecentPostItem = ({ postData }: { postData: GardenPost }) => {
       state: { data: { lat: latitude, lng: longitude } },
     });
     setGardenId(gardenId);
+    setShowGardenDetail(true);
   };
 
   return (

--- a/src/pages/Map/components/GardensContainer.tsx
+++ b/src/pages/Map/components/GardensContainer.tsx
@@ -12,16 +12,11 @@ const Button = chakra(motion.button);
 const GardenContainer = chakra(motion.div);
 
 interface GardensContainerProps {
-  showGardenDetail: boolean;
   gardenType: 'ALL' | 'PUBLIC' | 'PRIVATE';
   map: naver.maps.Map | null;
 }
 
-const GardensContainer = ({
-  showGardenDetail,
-  gardenType,
-  map,
-}: GardensContainerProps) => {
+const GardensContainer = ({ gardenType, map }: GardensContainerProps) => {
   const { isShowAside, setIsShowAside } = useShowMapAside();
   const [hasNext, setHasNext] = useState(false);
   const { startLat, startLong, endLat, endLong } = getMapBounds(map);
@@ -65,7 +60,6 @@ const GardensContainer = ({
           ) : (
             <MapAside
               {...{
-                showGardenDetail,
                 fetchNextPage,
                 hasNextPage,
                 hasNext,
@@ -125,7 +119,6 @@ const GardensContainer = ({
             ) : (
               <MapAside
                 {...{
-                  showGardenDetail,
                   fetchNextPage,
                   hasNextPage,
                   hasNext,

--- a/src/pages/Map/components/MapAside/MapAside.tsx
+++ b/src/pages/Map/components/MapAside/MapAside.tsx
@@ -2,9 +2,9 @@ import { Box } from '@chakra-ui/react';
 import GardenDetail from './components/GardenDetail/GardenDetail';
 import GardenList from './components/GardenList/GardenList';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import useShowGardenDetailStore from '@/stores/useShowGardenDetailStore';
 
 interface MapGardensProps {
-  showGardenDetail: boolean;
   hasNext: boolean;
   fetchNextPage: () => void;
   hasNextPage: boolean;
@@ -12,7 +12,6 @@ interface MapGardensProps {
 }
 
 const MapAside = ({
-  showGardenDetail,
   hasNext,
   fetchNextPage,
   hasNextPage,
@@ -24,6 +23,9 @@ const MapAside = ({
     },
     hasNextPage,
   });
+  const showGardenDetail = useShowGardenDetailStore(
+    (state) => state.showGardenDetail,
+  );
 
   return (
     <Box position="relative">

--- a/src/pages/Map/components/MapAside/components/GardenDetail/GardenDetail.tsx
+++ b/src/pages/Map/components/MapAside/components/GardenDetail/GardenDetail.tsx
@@ -10,7 +10,9 @@ import useShowGardenDetailStore from '@/stores/useShowGardenDetailStore';
 const GardenDetail = () => {
   const { gardenId } = useMapGardenDetailIdStore();
   const { data: gardenInfo, refetch } = useGetIndividualGarden(gardenId);
-  const { setShowGardenDetail } = useShowGardenDetailStore();
+  const setShowGardenDetail = useShowGardenDetailStore(
+    (state) => state.setShowGardenDetail,
+  );
 
   if (!gardenInfo)
     return (

--- a/src/pages/Map/components/MapAside/components/GardenList/GardenList.tsx
+++ b/src/pages/Map/components/MapAside/components/GardenList/GardenList.tsx
@@ -5,8 +5,10 @@ import useMapGardenDetailIdStore from '@/stores/useMapGardenDetailIdStore';
 import useShowGardenDetailStore from '@/stores/useShowGardenDetailStore';
 
 const GardenList = ({ gardens }: { gardens: Garden[] }) => {
-  const { setGardenId } = useMapGardenDetailIdStore();
-  const { setShowGardenDetail } = useShowGardenDetailStore();
+  const setGardenId = useMapGardenDetailIdStore((state) => state.setGardenId);
+  const setShowGardenDetail = useShowGardenDetailStore(
+    (state) => state.setShowGardenDetail,
+  );
 
   return gardens?.map((garden) => (
     <Box

--- a/src/pages/Map/components/MapComponent.tsx
+++ b/src/pages/Map/components/MapComponent.tsx
@@ -10,7 +10,6 @@ import MyMarker from './Marker/MyMarker';
 import useGeolocation from '@/hooks/useGeolocation';
 import { useGetMapGardens } from '@/services/gardens/query';
 import useMapGardenDetailIdStore from '@/stores/useMapGardenDetailIdStore';
-import useShowGardenDetailStore from '@/stores/useShowGardenDetailStore';
 
 interface MapComponentProps {
   map: naver.maps.Map | null;
@@ -23,16 +22,9 @@ const MapComponent = ({ map, setMap, headerOption }: MapComponentProps) => {
   const navermaps = useNavermaps();
   const geolocation = useGeolocation();
   const gardenType = getGardenType(headerOption);
-  const { showGardenDetail, setShowGardenDetail } = useShowGardenDetailStore();
   const { gardenId } = useMapGardenDetailIdStore();
   const { data: mapGardens, refetch } = useGetMapGardens(gardenType, map);
   const gardens: Garden[] = mapGardens?.gardenByComplexesResponses;
-
-  useEffect(() => {
-    setShowGardenDetail(
-      gardenId && location.state && location.state.data ? true : false,
-    );
-  }, [gardenId, location, setShowGardenDetail]);
 
   useEffect(() => {
     if (map) {
@@ -97,8 +89,6 @@ const MapComponent = ({ map, setMap, headerOption }: MapComponentProps) => {
     >
       <GardensContainer
         {...{
-          showGardenDetail,
-          setShowGardenDetail,
           gardenType,
           map,
         }}


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->
useEffect문을 제거하여 하나의 텃밭 항목 클릭 시 바로 텃밭 상세보기 컴포넌트가 렌더링 될 수 있도록 하였습니다.

- close #138 
